### PR TITLE
ci(security): use takumi guard

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,9 @@ jobs:
   build:
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
@@ -17,6 +20,10 @@ jobs:
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: '1.26.4'
+
+    - uses: flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1
+      with:
+        bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
 
     - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
       with:


### PR DESCRIPTION
Introduce takumi guard into the CI workflows to secure Go module downloads.

## Changes

- `.github/workflows/test.yaml` (`build` job):
  - Added a `permissions:` block with `contents: read` and `id-token: write` (the job previously had no permissions defined; `id-token: write` is required by takumi guard).
  - Added the `flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1` setup step immediately after `actions/setup-go` and before `aqua-installer` / the `go test` and `golangci-lint run` steps, with input `bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}`.

The `TAKUMI_GUARD_BOT_ID` secret must be configured in the repository/organization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)